### PR TITLE
Do not show JSON comments as errors in ReadmeV2.md

### DIFF
--- a/Analytics/AzureDataFactoryARMTemplates/SQLToADLSFullExport/ReadmeV2.md
+++ b/Analytics/AzureDataFactoryARMTemplates/SQLToADLSFullExport/ReadmeV2.md
@@ -36,7 +36,7 @@ Create an Azure Active directory application and secret, this  AAD Application i
 ![Clone](/Analytics/CloneRepository.PNG)
 2.  Open C# solution Microsoft.CommonDataModel.sln in Visual Studio 2019 and build
 3.  update local.setting.json under CDMUtil_AzureFunctions to as per your environment configurations   
-```json
+```jsonc
 {
   "IsEncrypted": false,
   "Values": {


### PR DESCRIPTION
Currently the shown JSON is hard to read due to the fact that comments are not valid in regular JSON.
![image](https://user-images.githubusercontent.com/5146032/95544321-12b19000-09fb-11eb-981c-67db537ea01b.png)
By using `jsonc` as language within the Markdown code block the data should be easier to read.