### PR TITLE
doc: add guidance to prevent error regarding not using AAD login

### DIFF
--- a/Analytics/AzureDataFactoryARMTemplates/SQLToADLSFullExport/ReadmeV2.md
+++ b/Analytics/AzureDataFactoryARMTemplates/SQLToADLSFullExport/ReadmeV2.md
@@ -71,6 +71,7 @@ CREATE EXTERNAL DATA SOURCE myenvironmentds WITH (
 );
 ```
 3. **Create Azure Function MSI App as User on SQL:**
+Make sure you use an AAD login for the connection to SQL-OnDemand, because otherwise you will receive an error that only AAD logins can perform this action.
 ```SQL
 use AXDB
 go


### PR DESCRIPTION
Error message is: Principal 'ABCCDMUtilAzureFunctions' could not be created. Only connections established with Active Directory accounts can create other Active Directory users.