### PR TITLE
Fix header empty check in getConfigurationValue (Issue #44)

### DIFF
--- a/Analytics/CDMUtilSolution/CDMUtil_AzureFunctions/CDMUtil.cs
+++ b/Analytics/CDMUtilSolution/CDMUtil_AzureFunctions/CDMUtil.cs
@@ -215,7 +215,7 @@ namespace CDMUtil
         {
             string ConfigValue;
             
-            if (req != null && String.IsNullOrEmpty(req.Headers[token]))
+            if (req != null && !String.IsNullOrEmpty(req.Headers[token]))
             {
                 ConfigValue = req.Headers[token];
             }


### PR DESCRIPTION
Fixes #44 

```c#
if (req != null && !String.IsNullOrEmpty(req.Headers[token]))
{
    ConfigValue = req.Headers[token];
}
```

The second expression in the if statement should ensure that the header collection does _not_ return null (meaning it has a value).