### PR TITLE
Add tokenized configuration resolution from ManifestUrl (for CDMUtil_AzureFunctions)

### DIFF
--- a/Analytics/CDMUtilSolution/CDMUtil_AzureFunctions/CDMUtil.cs
+++ b/Analytics/CDMUtilSolution/CDMUtil_AzureFunctions/CDMUtil.cs
@@ -215,7 +215,7 @@ namespace CDMUtil
         {
             string ConfigValue;
             
-            if (req != null && String.IsNullOrEmpty(req.Headers[token]))
+            if (req != null && !String.IsNullOrEmpty(req.Headers[token]))
             {
                 ConfigValue = req.Headers[token];
             }

--- a/Analytics/CDMUtilSolution/CDMUtil_AzureFunctions/CDMUtil.cs
+++ b/Analytics/CDMUtilSolution/CDMUtil_AzureFunctions/CDMUtil.cs
@@ -226,8 +226,8 @@ namespace CDMUtil
                 var storageAccount = uri.Host.Split('.')[0];
                 var pathSegments = uri.AbsolutePath.Split('/').Skip(1); // because of the leading /, the first entry will always be blank and we can disregard it
                 var n = pathSegments.Count();
-                while (n > 0 && ConfigValue == null)
-                    ConfigValue = System.Environment.GetEnvironmentVariable($"{storageAccount}:{String.Join(":", pathSegments.Take(n--))}:{token}");
+                while (n >= 0 && ConfigValue == null)
+                    ConfigValue = System.Environment.GetEnvironmentVariable($"{storageAccount}:{String.Join(":", pathSegments.Take(n--))}{(n > 0 ? ":" : "")}{token}");
             }
             else
             {

--- a/Analytics/CDMUtilSolution/CDMUtil_AzureFunctions/CDMUtil.cs
+++ b/Analytics/CDMUtilSolution/CDMUtil_AzureFunctions/CDMUtil.cs
@@ -211,13 +211,25 @@ namespace CDMUtil
             var statements = new SQLStatements { Statements = statementsList };
             sQLHandler.executeStatements(statements);
         }
-        public static string getConfigurationValue(HttpRequest req, string token)
+        public static string getConfigurationValue(HttpRequest req, string token, string url = null)
         {
             string ConfigValue;
             
             if (req != null && !String.IsNullOrEmpty(req.Headers[token]))
             {
                 ConfigValue = req.Headers[token];
+            }
+            else if (!String.IsNullOrEmpty(url))
+            {
+                var urlParts = url.Split('/');
+                var storageAccount = urlParts.Length >= 3 ? urlParts[2].Split('.')[0] : null;
+                var container = urlParts.Length >= 4 ? urlParts[3] : null;
+                var environment = urlParts.Length >= 5 ? urlParts[4] : null;
+                var folder = urlParts.Length >= 6 ? urlParts[5] : null;
+                ConfigValue = Environment.GetEnvironmentVariable($"{storageAccount}:{container}:{environment}:{folder}:{token}")
+                    ?? Environment.GetEnvironmentVariable($"{storageAccount}:{container}:{environment}:{token}")
+                    ?? Environment.GetEnvironmentVariable($"{storageAccount}:{container}:{token}")
+                    ?? Environment.GetEnvironmentVariable($"{storageAccount}:{token}");
             }
             else
             {
@@ -246,33 +258,33 @@ namespace CDMUtil
                 throw new Exception($"Invalid manifest URL:{ManifestURL}");
             }
 
-            string tenantId = getConfigurationValue(req, "TenantId");
-            string connectionString = getConfigurationValue(req, "SQLEndpoint");
-            string DDLType = getConfigurationValue(req, "DDLType");
+            string tenantId = getConfigurationValue(req, "TenantId", ManifestURL);
+            string connectionString = getConfigurationValue(req, "SQLEndpoint", ManifestURL);
+            string DDLType = getConfigurationValue(req, "DDLType", ManifestURL);
             
             AppConfigurations AppConfiguration = new AppConfigurations(tenantId, ManifestURL, null, connectionString, DDLType);
 
-            string dataSourceName = getConfigurationValue(req, "DataSourceName");
+            string dataSourceName = getConfigurationValue(req, "DataSourceName", ManifestURL);
             if (dataSourceName != null)
                 AppConfiguration.synapseOptions.external_data_source = dataSourceName;
 
-            string schema = getConfigurationValue(req, "Schema");
+            string schema = getConfigurationValue(req, "Schema", ManifestURL);
             if (schema != null)
                 AppConfiguration.synapseOptions.schema = schema;
 
-            string fileFormat = getConfigurationValue(req, "FileFormat");
+            string fileFormat = getConfigurationValue(req, "FileFormat", ManifestURL);
             if (fileFormat != null)
                 AppConfiguration.synapseOptions.fileFormatName = fileFormat;
             
-            string DateTimeAsString = getConfigurationValue(req, "DateTimeAsString");            
+            string DateTimeAsString = getConfigurationValue(req, "DateTimeAsString", ManifestURL);            
             if (DateTimeAsString != null)
                 AppConfiguration.synapseOptions.DateTimeAsString = bool.Parse(DateTimeAsString);
             
-            string ConvertDateTime = getConfigurationValue(req, "ConvertDateTime");
+            string ConvertDateTime = getConfigurationValue(req, "ConvertDateTime", ManifestURL);
             if (ConvertDateTime != null)
                 AppConfiguration.synapseOptions.ConvertDateTime = bool.Parse(ConvertDateTime);
 
-            string TranslateEnum = getConfigurationValue(req, "TranslateEnum");
+            string TranslateEnum = getConfigurationValue(req, "TranslateEnum", ManifestURL);
             if (TranslateEnum != null)
                 AppConfiguration.synapseOptions.TranslateEnum = bool.Parse(TranslateEnum);
 

--- a/Analytics/CDMUtilSolution/CDMUtil_AzureFunctions/CDMUtil.cs
+++ b/Analytics/CDMUtilSolution/CDMUtil_AzureFunctions/CDMUtil.cs
@@ -224,10 +224,10 @@ namespace CDMUtil
             {
                 var uri = new Uri(url);
                 var storageAccount = uri.Host.Split('.')[0];
-                var pathSegments = uri.AbsolutePath.Split('/');
-                var n = pathSegments.Length;
-                while (n > 1 && ConfigValue == null) // because of the leading /, the first entry will always be blank and we can disregard it
-                    ConfigValue = Environment.GetEnvironmentVariable($"{storageAccount}:{String.Join(":", pathSegments.Take(n--))}:{token}");
+                var pathSegments = uri.AbsolutePath.Split('/').Skip(1); // because of the leading /, the first entry will always be blank and we can disregard it
+                var n = pathSegments.Count();
+                while (n > 0 && ConfigValue == null)
+                    ConfigValue = System.Environment.GetEnvironmentVariable($"{storageAccount}:{String.Join(":", pathSegments.Take(n--))}:{token}");
             }
             else
             {


### PR DESCRIPTION
As the Azure Function is currently written, we only extract the Url from the event payload, and thus expect that the function's environment variables/config will supply the rest of the required configuration parameters. This effectively locks a single instance of the Azure Function to be able to serve only one F&O environment's worth of data lake CDM files/SQLEndpoint.

To make the Azure Function more reusable in the EventGrid flow and enable using a single function instance to handle many events from different environments' cdm folders, storage accounts, etc., I have added a scheme for parsing the context that is present in the url's path segments, and then providing a mechanism to try to resolve configuration tokens from the environment with these as qualifiers (following a most-specific to least-specific resolution path).

The idea is we decompose a ManifestURL into context tokens, extracting the Storage Account name from the host, and then treating each segment in the URI's Path as an increasingly specific context qualifier.
Given the ManifestURL of https://youradls.blob.core.windows.net/dynamics365-financeandoperations/yourenvvi.sandbox.operations.dynamics.com/Tables/Tables.manifest.cdm.json
we have:
storageAccount: youradls
and then path segments
dynamics365-financeandoperations
yourenvvi.sandbox.operations.dynamics.com
Tables
Tables.manifest.cdm.json

When resolving configuration tokens (when the request does not contain the token(s) in the header), we check to see if the Environment has a value defined for one of the combinations of these context qualifiers and the actual config token being resolved, in most- to least-specific order. For example:
trying to resolve Schema, given the ManifestUrl of "https://youradls.blob.core.windows.net/dynamics365-financeandoperations/yourenvvi.sandbox.operations.dynamics.com/Tables/Tables.manifest.cdm.json", we would test the environment for a variable with one of these names in the following order:
youradls:dynamics365-financeandoperations:yourenvvi.sandbox.operations.dynamics.com:Tables:Tables.manifest.cdm.json:Schema
youradls:dynamics365-financeandoperations:yourenvvi.sandbox.operations.dynamics.com:Tables:Schema
youradls:dynamics365-financeandoperations:yourenvvi.sandbox.operations.dynamics.com:Schema
youradls:dynamics365-financeandoperations:Schema
youradls:Schema
The first such name to return a non-null result wins, and we stop searching. If no value is found, we fall through to the current behavior. 

To specify context-specific config values in the config, we would then assemble a context-qualified config token as such:
Say we want to declare that all cdm handling in an entire storage account should default to a common DataSourceName
Evironment/config file key: youradls:DataSourceName

As we are doing in our usage of the Export to Data Lake feature & CDMUtil & Synapse, we are mounting both the Tables and ChangeFeed to the same database in Synapse, but with the objects presented in different schemas. We can thus control this by setting
youradls:dynamics365-financeandoperations:yourenvvi.sandbox.operations.dynamics.com:Tables:Schema = dbo
youradls:dynamics365-financeandoperations:yourenvvi.sandbox.operations.dynamics.com:ChangeFeed:Schema = change

