### PR TITLE
CDMUtil_ConsoleApp: ConvertDateTime parameter doesn't read correctly from config file

### DIFF
--- a/Analytics/CDMUtilSolution/CDMUtil_ConsoleApp/Program.cs
+++ b/Analytics/CDMUtilSolution/CDMUtil_ConsoleApp/Program.cs
@@ -94,7 +94,7 @@ namespace CDMUtil
 
             if (ConfigurationManager.AppSettings.Get("ConvertDateTime") != null)
             {
-                AppConfiguration.synapseOptions.DateTimeAsString = bool.Parse(ConfigurationManager.AppSettings.Get("ConvertDateTime"));
+                AppConfiguration.synapseOptions.ConvertDateTime = bool.Parse(ConfigurationManager.AppSettings.Get("ConvertDateTime"));
             }
             if (ConfigurationManager.AppSettings.Get("DataSourceName") != null)
             {


### PR DESCRIPTION
CDMUtil_ConsoleApp: ConvertDateTime parameter doesn't read correctly from config file