### PR TITLE
Replace GETUTCDATE function with SYSUTCDATETIME

### DIFF
--- a/Analytics/CDMUtilSolution/CDMUtil/SQL/ReplaceViewSyntax.json
+++ b/Analytics/CDMUtilSolution/CDMUtil/SQL/ReplaceViewSyntax.json
@@ -38,5 +38,9 @@
   {
     "Key": " ELSE T1.STARTDATE2 - 1 END",
     "Value": " ELSE DateAdd(Day, -1, T1.STARTDATE2) END"
+  },
+  {
+    "Key": "GETUTCDATE()",
+    "Value": "SYSUTCDATETIME()"
   }
 ]


### PR DESCRIPTION
Replace GETUTCDATE function with SYSUTCDATETIME to avoid conversion from datetime2 type to datetime