### PR TITLE
fix: TranslateEnum throws error and was not backward compatible

### DIFF
--- a/Analytics/CDMUtilSolution/CDMUtil/SQL/SQLHandler.cs
+++ b/Analytics/CDMUtilSolution/CDMUtil/SQL/SQLHandler.cs
@@ -240,17 +240,16 @@ namespace CDMUtil.SQL
                     if (synapseDBOptions.TranslateEnum == true && attribute.constantValueList != null)
                     {
                         var constantValues = attribute.constantValueList.ConstantValues;
-                        sqlColumnNames += $" ,CASE {attribute.name}";
+                        sqlColumnNames += $" CASE {attribute.name}";
                         foreach (var constantValueList in constantValues)
                         {
                             sqlColumnNames += $"{ " When " + constantValueList[3] + " Then '" + constantValueList[2]}'";
                         }
                         sqlColumnNames += $" END AS {attribute.name}_Label";
+                        sqlColumnNames += $",";
                     }
-                    else
-                    {
-                        sqlColumnNames = $"{attribute.name}";
-                    }
+                    sqlColumnNames += $"{attribute.name}";
+
                     break;
                 default:
                     sqlColumnNames = $"{attribute.name}";


### PR DESCRIPTION
- TranslateEnum throws the following error: _Incorrect syntax near ','. Incorrect syntax near the keyword 'with'. If this statement is a common table expression, an xmlnamespaces clause or a change tracking context clause, the previous statement must be terminated with a semicolon._
- Adding the "plain" enum integer field for backwards compatibility