### PR TITLE
Bugfix Parameter exceeds maximum allowed (4000).

### DIFF
--- a/Analytics/SynapseToSQL_ADF/SynapseToSQL_DestSetupScript.sql
+++ b/Analytics/SynapseToSQL_ADF/SynapseToSQL_DestSetupScript.sql
@@ -98,7 +98,7 @@ CREATE OR ALTER PROC [dbo].[publishTable]
 @TableName nvarchar(100), 
 @CDCTableName nvarchar(100),
 @PrimaryTableName nvarchar(100),
-@ColumnNames nvarchar(8000)
+@ColumnNames varchar(8000)
 as 
 begin
 	


### PR DESCRIPTION
The last commit added a bug. The execution returns:

`Msg 2717, Level 16, State 2, Procedure publishTable, Line 7 [Batch Start Line 0] The size (8000) given to the parameter '@ColumnNames' exceeds the maximum allowed (4000).`

The 8000 only works with varchar. 
I tested it on an SQL Server 2022 and on a Azure SQL Database.