### PR TITLE
Requriements for Console Application

### DIFF
--- a/Analytics/CDMUtilSolution/readme.md
+++ b/Analytics/CDMUtilSolution/readme.md
@@ -52,7 +52,7 @@ CDMUtil can be deployed as Azure Function to convert CDM metadata to Synapse Ana
 (![Events Filters](https://user-images.githubusercontent.com/65608469/173087789-c45104a6-ce44-4d99-8fc7-9be3d2856caf.png)
 
 ## 2. CDMUtil Console App 
-To run CDMUtil from local desktop, you can download and run CDMUtil executable using Command prompt or Powershell. 
+To run CDMUtil from local desktop, you can download and run CDMUtil executable using Command prompt or Powershell.
 
 1. Download the Console Application executables [CDMUtilConsoleApp.zip](/Analytics/CDMUtilSolution/CDMUtilConsoleApp.zip)
 2. Extract the zip file and extract to local folder 


### PR DESCRIPTION
Without .net Core Framework 3.1 installed the application closes itself immediately. Via powershell you can get this error: 
```
PS C:\Users\xxx\Desktop\CDMUtilConsoleApp> &.\CDMUtil_ConsoleApp.exe
You must install or update .NET to run this application.

App: C:\Users\xxx\Desktop\CDMUtilConsoleApp\CDMUtil_ConsoleApp.exe
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '3.1.0' (x64)
.NET location: C:\Program Files\dotnet\

The following frameworks were found:
  6.0.14 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  7.0.3 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]

Learn about framework resolution:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=3.1.0&arch=x64&rid=win10-x64
```