### PR TITLE
Fix schema due to an error in the script DBO.

### DIFF
--- a/Analytics/DataverseLink/EDL_To_SynapseLinkDV_DBSetup/Step1_EDL_To_SynapseLinkDV_CreateUpdate_SetupScript.sql
+++ b/Analytics/DataverseLink/EDL_To_SynapseLinkDV_DBSetup/Step1_EDL_To_SynapseLinkDV_CreateUpdate_SetupScript.sql
@@ -345,7 +345,7 @@ from
 			GlobalOptionSetName as enum,
 			[Option] as enumid ,
 			b.enumitemvalue as enumvalue
-			from dbo.GlobalOptionsetMetadata as a
+			from GlobalOptionsetMetadata as a
 			left outer join srsanalysisenums as b ON a.GlobalOptionSetName = 'mserp_' + lower(b.enumname)
 			and a.ExternalValue = b.enumitemname
 			where LocalizedLabelLanguageCode = 1033 -- this is english


### PR DESCRIPTION
Fix schema due to an error in the script DBO instead of empty or dvtosql.