### PR TITLE
Update Step1_EDL_To_SynapseLinkDV_CreateUpdate_SetupScript_DW.sql

### DIFF
--- a/Analytics/DataverseLink/CloudDataWarehouse_SynapseDW/Step1_EDL_To_SynapseLinkDV_CreateUpdate_SetupScript_DW.sql
+++ b/Analytics/DataverseLink/CloudDataWarehouse_SynapseDW/Step1_EDL_To_SynapseLinkDV_CreateUpdate_SetupScript_DW.sql
@@ -234,10 +234,6 @@ AS
         FROM {schema}._new_{tablename} t
         INNER JOIN #TempDuplicates{tablename} tmp ON t.Id = tmp.Id and t.versionnumber = tmp.versionnumber and t.SinkCreatedOn = tmp.SinkCreatedOn;
 
-        DELETE t
-        FROM {schema}._new_{tablename} t
-		where t.IsDelete = 1;
-
         drop table  #TempDuplicates{tablename};
 
         END'


### PR DESCRIPTION
The proposal for deletion of code rows is because they prevent correct handling of deleted data.
Because the deleted rows are deleted in the _tmp-table (current code rows 237-239) the corresponding data in the target table won't be deleted anymore (see code rows 289-292).
Due to this deleted rows will stay in the target tables forever and through deletion of deleted rows in the _tmp-table there aren't any traces that a deletion has happened.
