### PR TITLE
Filter by the correct schema (bug)

### DIFF
--- a/Analytics/DataverseLink/FabricLink_SQLAnalyticsEndpoint/DVFabricLinkUtil/get_lh_ddl_as_view.sql
+++ b/Analytics/DataverseLink/FabricLink_SQLAnalyticsEndpoint/DVFabricLinkUtil/get_lh_ddl_as_view.sql
@@ -220,7 +220,7 @@ CREATE TABLE #enumtranslationdist (
                               maxLength INT
                           )
                       ) z ON C.TABLE_NAME = LOWER(z.tablename) AND C.COLUMN_NAME = LOWER(z.columnname)
-                      WHERE TABLE_SCHEMA = @target_table_schema
+                      WHERE TABLE_SCHEMA = @source_table_schema
                         AND TABLE_NAME = childtable
                         AND COLUMN_NAME NOT IN (
                             SELECT value 
@@ -235,7 +235,7 @@ CREATE TABLE #enumtranslationdist (
                 )
                 cross apply openjson(childtables) with (childtable nvarchar(200))
 			    where 
-                childtable in (select distinct TABLE_NAME from INFORMATION_SCHEMA.COLUMNS C where TABLE_SCHEMA = @target_table_schema and lower(C.TABLE_NAME)  = lower(childtable))
+                childtable in (select distinct TABLE_NAME from INFORMATION_SCHEMA.COLUMNS C where TABLE_SCHEMA = @source_table_schema and lower(C.TABLE_NAME)  = lower(childtable))
                 and   lower(childtable) in (select distinct lower(tablename) FROM #sqltadata)
           ) x
           GROUP BY parenttable


### PR DESCRIPTION
The filtering must happen on source_table_schema, not target_table_schema. This bugs shows whenever source_table_schema<>target_table_schema and join_derived_tables=1

Solves issue #367