### PR TITLE
Update switching from LEAST() to CASE for NBRecordsEligible

### DIFF
--- a/Storage Management/Large Tables Data Cleanup/3B-RemoveOrphans.SQL
+++ b/Storage Management/Large Tables Data Cleanup/3B-RemoveOrphans.SQL
@@ -243,7 +243,11 @@ BEGIN
 			PRINT @SQL
 			EXEC sp_executesql @SQL, N'@NBRecordsEligible BIGINT OUTPUT ', @nbRecordsEligible OUTPUT
 
-			SELECT @NBRecordsEligible = LEAST(@NBRecordsEligible, @BatchSize) ;
+			SELECT @NBRecordsEligible =
+				CASE WHEN @NBRecordsEligible < @BatchSize
+				THEN @NBRecordsEligible
+				ELSE @BatchSize
+			END;
 
 			IF @maxRecId = 0
 			BEGIN


### PR DESCRIPTION
This change replaces the use of the LEAST() function inside the RemoveOrphansOnTablesWithoutDateTime stored procedure with a SQL Server–compliant CASE expression.

Recent versions of SqlPackage/DacFx (v162+) now perform strict validation of stored procedure bodies during BACPAC imports. As part of that validation, the procedure is parsed and compiled using SQL Server’s T‑SQL rules. Because SQL Server does not support the LEAST() function, the BACPAC import fails with:

```
'LEAST' is not a recognized built-in function name.
SQL72014 / SQL72045
```

Older SqlPackage versions did not validate SP bodies at this level, which is why this had not surfaced previously.
To restore compatibility, the call to LEAST(@NBRecordsEligible, @BatchSize) has been replaced with the equivalent conditional expression:

```
SQLSELECT @NBRecordsEligible =
CASE WHEN @NBRecordsEligible < @BatchSize
THEN @NBRecordsEligible
ELSE @BatchSize
END;
```

This maintains identical behavior but ensures SQL Server and SqlPackage accept the procedure during deployment.
No functional or behavioral changes beyond this fix. This update resolves the BACPAC import failure and aligns the stored procedure with T‑SQL standards.